### PR TITLE
Fix(web): 온보딩 후 로드맵 생성 시간 동안 홈, 로드맵 페이지 로띠 추가

### DIFF
--- a/apps/web/src/entities/phase/queries/queries.ts
+++ b/apps/web/src/entities/phase/queries/queries.ts
@@ -9,11 +9,17 @@ import { getAiGuide } from '@entities/phase/api/get-ai-guide';
 import { GetAiGuideRequest } from '@entities/phase/model/types';
 import { PHASE_QUERY_KEY } from '@entities/phase/queries';
 
+const POLLING_COUNT_DOWM_TIMER = 2000;
+
 export const PHASE_QUERY_OPTIONS = {
   GET_PHASE_LIST: () => {
     return queryOptions({
       queryKey: PHASE_QUERY_KEY.PHASE_LIST(),
       queryFn: getPhaseList,
+      refetchInterval: (query) => {
+        const phases = query.state.data?.phases ?? [];
+        return phases.length === 0 ? POLLING_COUNT_DOWM_TIMER : false;
+      },
     });
   },
   GET_PHASE_ITEM_HOME: (phaseId: number) => {

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -1,8 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
 import { VisaStatusListSection } from '@widgets/dashboard/ui';
 import { MyBookmarkedJobsSection } from '@widgets/dashboard/ui';
 import { PhaseOverviewSection } from '@widgets/dashboard/ui';
+import { PHASE_QUERY_OPTIONS } from '@entities/phase/queries';
+import { PageLoader } from '@shared/ui';
 
 const DashboardPage = () => {
+  const { data } = useQuery({ ...PHASE_QUERY_OPTIONS.GET_PHASE_LIST() });
+  const hasPhaseData = (data?.phases ?? []).length > 0;
+
+  if (!hasPhaseData) {
+    return <PageLoader text="Please wait a bit..." />;
+  }
+
   return (
     <>
       <VisaStatusListSection />

--- a/apps/web/src/pages/roadmap/roadmap-page.tsx
+++ b/apps/web/src/pages/roadmap/roadmap-page.tsx
@@ -1,6 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
 import { RoadmapSection } from '@widgets/roadmap';
+import { PHASE_QUERY_OPTIONS } from '@entities/phase/queries';
+import { PageLoader } from '@shared/ui';
 
 const RoadmapPage = () => {
+  const { data } = useQuery({ ...PHASE_QUERY_OPTIONS.GET_PHASE_LIST() });
+  const hasPhaseData = (data?.phases ?? []).length > 0;
+
+  if (!hasPhaseData) {
+    return <PageLoader text="Please wait a bit..." />;
+  }
+
   return (
     <>
       <RoadmapSection />


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #215 

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

- 온보딩 후 로드맵 생성 시간 동안 홈, 로드맵 페이지 로띠 추가

기존에 fallback으로 PageLoader를 설정해둬서 온보딩이 끝난 뒤에 PageLoader가 뜰 줄 알았어요.
하지만 이건 저의 착오였습니다.
suspense는 코드 로딩에만 반응을 하여 GlobalLayout의 Suspense는 `lazy로딩으로 로드되는 컴포넌트`가 아직 로드되지 않았을 때만 fallback이라고 떠요.
하지만 fetching은 기본 설정에서 Suspense를 트리거하지 않으니 페이지는 바로 렌더링되고 PageLoader가 뜨지 않았어요.
그리고 라우트 컴포넌트가 이미 로드된 상태면 fallback UI가 뜨지 않기 때문에 초기 진입이 아니거나 캐시/프리로드가 있으면 Suspense에 걸릴 일도 없었어요. 즉, 온보딩에서 로드맵 생성 후 홈 페이지로 이동 후 다른 페이지로 갔다가 다시 페이지를 이동하면 fallback UI가 뜨지 않습니다.

따라서 layout의 fallback으로 지정해둔 내용은 데이터 로딩용이 아니라 코드 스플릿 로딩용이어서 Phase에 해당하는 API의 대기 상태에서는 보이지 않았어요.

그래서 저는 대시보드나 로드맵에 진입 시 로드맵이 생성되지 않으면 200 OK가 뜨지만 데이터가 빈 값으로 오는걸 확인하였고 데이터 로딩 중에 fallback UI를 사용하기 위해 `대시보드 페이지`와 `로드맵 페이지`에서 GET_PHASE_LIST 쿼리를 직접 호출하여 응답의 phases가 비어 있으면 PageLoder를 렌더링하도록 구현했어요.
이때 refetchInterval로 2초 폴링되도록 했고, 데이터가 들어옴녀 폴링이 종료되고 바로 화면에 렌더링 되도록 수정했어요!


## 👀 To Reviewer

일단 2초가 괜찮을것 같아서 2초로 두었습니다! (2초 정도가 많이 쓰인다고 하더라구요!)

## 📸 Screenshot

![화면 기록 2026-01-23 오후 6 50 50](https://github.com/user-attachments/assets/a6e457f2-bf18-4534-a419-0057167c7981)


<!--
(기재 내용 없을 경우 섹션 삭제)
UI 변경사항이 있는 경우 스크린샷을 첨부해주세요.
동적인 변화는 GIF로 첨부하면 더 좋습니다!
-->
