### PR TITLE
Fix(web): 브라우저별 api 대응

### DIFF
--- a/apps/web/src/entities/job/api/recommended-job-posting.ts
+++ b/apps/web/src/entities/job/api/recommended-job-posting.ts
@@ -17,6 +17,7 @@ export const recommendJobPostings = async (
         includeCompletedTodo: params.includeCompletedTodo ?? false,
       },
       body: formData,
+      duplex: 'half',
       timeout: false,
     })
     .json<RecommendJobPostingsResponse>();

--- a/apps/web/src/shared/types/ky.d.ts
+++ b/apps/web/src/shared/types/ky.d.ts
@@ -1,0 +1,9 @@
+import '@toss/ky';
+
+declare module '@toss/ky' {
+  interface Options {
+    duplex?: 'half';
+  }
+}
+
+export {};


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #227 

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

- 북마크 api 호출에 duplex 속성 추가

테스트 중에 같은 계정으로 다른 노트북에서 크롬에 접속하여 로그인 후 북마크 리스트를 조회했을 때 어떤 크롬 브라우저에서는 조회가 잘 되고 어떤 크롬 브라우저에서는 조회가 되지 않았어요.
확인 해보니 일부 Chrome 버전에서 스트리밍 바디(ky 내부 처리 포함)일 때 duplex가 없으면 요청 생성이 실패한다고 해요.
따라서 duplex 속성을 추가했어요.
