### PR TITLE
Fix(web): 라우터 로더 가드 개선

### DIFF
--- a/apps/web/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/web/src/pages/onboarding/onboarding-page.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FormProvider, useForm, useWatch } from 'react-hook-form';
 
 import {
@@ -22,9 +22,11 @@ import {
   OnboardingForm,
   STEP_TITLES,
 } from '@entities/onboarding';
+import { USER_QUERY_KEY } from '@entities/user/queries';
 import useFunnel from '@shared/hooks/usefunnel';
 
 const OnboardingPage = () => {
+  const queryClient = useQueryClient();
   const { Funnel, Step, goToNextStep, goToPrevStep, currentStepIndex } =
     useFunnel(FUNNEL_STEPS, '/');
   const [error, setError] = useState<Error | null>(null);
@@ -93,7 +95,10 @@ const OnboardingPage = () => {
 
   const { mutate: submitOnboarding } = useMutation({
     mutationFn: postOnboardingForm,
-    onSuccess: () => {
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: USER_QUERY_KEY.USER_STATUS(),
+      });
       // 온보딩 성공 후 로드맵 생성 API 호출
       generateRoadmap();
       goToNextStep();

--- a/apps/web/src/shared/router/loader.ts
+++ b/apps/web/src/shared/router/loader.ts
@@ -3,7 +3,16 @@ import { type LoaderFunctionArgs, redirect } from 'react-router';
 import { USER_QUERY_OPTIONS } from '@entities/user/queries';
 import { queryClient } from '@shared/apis/providers/query-client';
 import { authService } from '@shared/auth/auth-service';
+import { HTTP_STATUS_CODE } from '@shared/constants/HTTP_STATUS_CODE';
 import { ROUTE_PATH } from '@shared/router';
+import { isHttpError } from '@shared/utils/http-error';
+
+export const requireAuth = () => {
+  if (!authService.isAuthenticated()) {
+    throw redirect(ROUTE_PATH.LOGIN);
+  }
+  return null;
+};
 
 export const guestOnlyLoader = ({ request }: LoaderFunctionArgs) => {
   if (authService.isAuthenticated()) {
@@ -13,22 +22,51 @@ export const guestOnlyLoader = ({ request }: LoaderFunctionArgs) => {
   return null;
 };
 
-export const requireAuthLoader = () => {
-  if (!authService.isAuthenticated()) {
-    throw redirect(ROUTE_PATH.LOGIN);
+export const appRouteLoader = async () => {
+  requireAuth();
+
+  try {
+    const userStatus = await queryClient.ensureQueryData(
+      USER_QUERY_OPTIONS.GET_USER_STATUS(),
+    );
+
+    if (userStatus.onboardingRequired) {
+      throw redirect(ROUTE_PATH.ONBOARDING);
+    }
+  } catch (error) {
+    if (
+      isHttpError(error) &&
+      error.response?.status === HTTP_STATUS_CODE.FORBIDDEN
+    ) {
+      throw redirect(ROUTE_PATH.ONBOARDING);
+    }
+
+    throw error;
   }
+
   return null;
 };
 
 export const onboardingGuardLoader = async () => {
-  requireAuthLoader();
+  requireAuth();
 
-  const userStatus = await queryClient.ensureQueryData(
-    USER_QUERY_OPTIONS.GET_USER_STATUS(),
-  );
+  try {
+    const userStatus = await queryClient.ensureQueryData(
+      USER_QUERY_OPTIONS.GET_USER_STATUS(),
+    );
 
-  if (userStatus.onboardingRequired === false) {
-    throw redirect(ROUTE_PATH.DASHBOARD);
+    if (userStatus.onboardingRequired === false) {
+      throw redirect(ROUTE_PATH.DASHBOARD);
+    }
+  } catch (error) {
+    if (
+      isHttpError(error) &&
+      error.response?.status === HTTP_STATUS_CODE.FORBIDDEN
+    ) {
+      return null;
+    }
+
+    throw error;
   }
 
   return null;

--- a/apps/web/src/shared/router/router.tsx
+++ b/apps/web/src/shared/router/router.tsx
@@ -4,9 +4,9 @@ import { ROUTE_PATH } from '@shared/router';
 import AppRouteLayout from '@shared/router/app-route-layout';
 import { LoginPage, OnboardingPage } from '@shared/router/lazy';
 import {
+  appRouteLoader,
   guestOnlyLoader,
   onboardingGuardLoader,
-  requireAuthLoader,
 } from '@shared/router/loader';
 import OnboardingRouteLayout from '@shared/router/onboarding-route-layout';
 import {
@@ -33,7 +33,7 @@ export const router = createBrowserRouter([
   },
   {
     Component: AppRouteLayout,
-    loader: requireAuthLoader,
+    loader: appRouteLoader,
     children: protectedAppRoutes,
   },
 ]);


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #253 

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

- 온보딩 loader 수정
- 온보딩 폼 제출 시 USER_STATUS 쿼리키 무효화

## 👀 To Reviewer
로그인 콜백에서 `onboardingRequired=true`를 받아 `/onboarding`으로 이동하는 흐름에서 `/onboarding` 진입 시 `onboardingGuardLoader`가 getUserStatus를 먼저 호출하고 신규 가입자(온보딩 미완료)는 이 API가 403을 반환해서 에러 바운더리로 떨어지는 문제가 있었어요. 또 앱 레이아웃은 기존에 로그인 인증 여부만 확인해서 온보딩 미완료 사용자가 앱 라우트에 접근 가능한 문제가 있었습니다. 추가로 온보딩 완료 직후 USER_STATUS 캐시가 남아 있으면 라우트 가드 판단이 일시적으로 어긋날 가능성이 있었어요.

따라서 라우터 가드를 개선했습니다.

라우터 가드는 인증과 온보딩 상태 책임을 분리해 구성했어요. `requireAuth`는 인증 체크만 담당하고, `appRouteLoader`는 앱 라우트 접근시 인증을 확인한 뒤 `onboardingRequired=true`이거나 `getUserStatus`가 `403`을 반환하면 `/onboarding`으로 리다이렉트하도록 했어요. 또한 온보딩 가드에서는 `getUserStatus`가 `403`일 때 온보딩 접근을 허용하고 `onboardingRequired=false`인 경우에는 대시버드 페이지로 리다이렉트 하도록 했어요. 
마지막으로 `ensureQueryData`는 캐시가 있으면 캐시를 그대로 반환하므로 온보딩 제출 성공 시 `USER_STATUS` 쿼리를 `invalidate`하도록 처리했어요.

우선 403일때로 처리했지만 403은 향후 권한 정책이나 계정 상태 정책이 확장되면 다른 의미로도 사용될 수 있으니 이후 관련 기능이 추가되면 백엔드 에러코드 기반으로 분기해도 괜찮을것 같네요!

<!--
(기재 내용 없을 경우 섹션 삭제)
더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

## 📸 Screenshot

<!--
(기재 내용 없을 경우 섹션 삭제)
UI 변경사항이 있는 경우 스크린샷을 첨부해주세요.
동적인 변화는 GIF로 첨부하면 더 좋습니다!
-->
