### PR TITLE
Feat(web): Request Header Language-Acceept Setting

### DIFF
--- a/apps/web/src/shared/apis/configs/instance.ts
+++ b/apps/web/src/shared/apis/configs/instance.ts
@@ -4,8 +4,8 @@ import { appConfig } from '@shared/apis/configs/app-config';
 import { isHttpError } from '@shared/utils/http-error';
 
 import {
-  handleCheckAndSetPreferredLanguage,
   handleCheckAndSetToken,
+  handleSetPreferredLanguage,
   handleUnauthorizedResponse,
 } from './interceptor';
 
@@ -39,7 +39,7 @@ export const api: ReturnType<typeof ky.create> = ky.create({
   retry: 0,
   hooks: {
     beforeError: [beforeErrorHook],
-    beforeRequest: [handleCheckAndSetPreferredLanguage, handleCheckAndSetToken],
+    beforeRequest: [handleSetPreferredLanguage, handleCheckAndSetToken],
     afterResponse: [handleUnauthorizedResponse],
   },
 });

--- a/apps/web/src/shared/apis/configs/interceptor.ts
+++ b/apps/web/src/shared/apis/configs/interceptor.ts
@@ -88,7 +88,7 @@ const getReissueToken = () => {
  *
  * @param request - 전송할 요청 객체
  */
-export const handleCheckAndSetPreferredLanguage = (request: Request) => {
+export const handleSetPreferredLanguage = (request: Request) => {
   const requestUrl = request.url;
   const currentLanguage = i18n.resolvedLanguage ?? i18n.language;
   const preferredLanguage = SUPPORTED_LANGUAGES.some(


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #277 

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

다국어 적용에 따라 api 요청 header에 X-Preferred-Language를 추가했어요.
따라서 사용자가 선택한 언어를 서버에 보내서 서버에서 내려주는 api의 response가 해당 언어에 맞게 내려오도록 해요.
그리고 Auth는 request header에 X-Preferred-Language가 들어가면 안돼서

```tsx
 if (isAuthExchangeRequest(requestUrl)) {
    return;
  }
```
이렇게 예외를 걸어놨습니다.

## 👀 To Reviewer

# 모두 집중!
# BackLog
언어 변경 시 언어에 따라 응답이 달라지는 데이터에 한해서만 TanStack Query의 queryKey에 locale 값을 포함해 관리하고 locale 변경 시 해당 query가 다시 조회되도록 처리하면 됩니다. 

## 📸 Screenshot
api요청 Request Header 부분
<img width="230" height="28" alt="image" src="https://github.com/user-attachments/assets/a31f9fa9-1fbe-422f-84ea-0e92dd32980b" />


<!--
(기재 내용 없을 경우 섹션 삭제)
더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->



<!--
(기재 내용 없을 경우 섹션 삭제)
UI 변경사항이 있는 경우 스크린샷을 첨부해주세요.
동적인 변화는 GIF로 첨부하면 더 좋습니다!
-->
