### PR TITLE
Feat(web): Preparation Status Checkbox 구현

### DIFF
--- a/apps/web/src/widgets/onboarding/ui/step/personal-backgorund/personal-background.css.ts
+++ b/apps/web/src/widgets/onboarding/ui/step/personal-backgorund/personal-background.css.ts
@@ -72,4 +72,5 @@ export const checkItem = style({
   display: 'flex',
   alignItems: 'center',
   gap: '0.8rem',
+  cursor: 'pointer',
 });

--- a/apps/web/src/widgets/onboarding/ui/step/personal-backgorund/personal-background.tsx
+++ b/apps/web/src/widgets/onboarding/ui/step/personal-backgorund/personal-background.tsx
@@ -85,11 +85,12 @@ const PersonalBackground = () => {
           <span>Current Preparation Status</span>
           <div className={styles.check({ area: 'list' })}>
             {PREPARATION_STATUS_OPTIONS.map((status) => (
-              <div key={status} className={styles.checkItem}>
-                <Checkbox
-                  isChecked={selectedStatus.includes(status)}
-                  onClick={() => handleToggle(status)}
-                />
+              <div
+                key={status}
+                className={styles.checkItem}
+                onClick={() => handleToggle(status)}
+              >
+                <Checkbox isChecked={selectedStatus.includes(status)} />
                 <span>{status}</span>
               </div>
             ))}


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #291 

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

- Preparation Status Checkbox 구현했어요.
- Personal Background 하단에 Current Preparation Status 영역이 추가되어서 기존 레이아웃 스타일을 일부 수정했어요.

## 👀 To Reviewer

- 온보딩 v2 api 연결 작업 시에 한번에 작업하는 게 나을 것 같아서 일단은 체크 상태를 `selectedStatus` 상태 변수로 관리하도록 구현해 두었어요.

## 📸 Screenshot


https://github.com/user-attachments/assets/008c3b9e-ffe4-4716-8172-b1d809941448

