### PR TITLE
Fix(web): 언어 변경 드롭다운 컴포넌트 option 각 언어로 수정

### DIFF
--- a/apps/web/src/features/onboarding/ui/language-selector/language-selector.tsx
+++ b/apps/web/src/features/onboarding/ui/language-selector/language-selector.tsx
@@ -7,17 +7,14 @@ import { LANGUAGE_OPTIONS } from '@shared/i18n/constants';
 import * as styles from './language-selector.css';
 
 const LanguageSelector = () => {
-  const { i18n, t } = useTranslation();
-  const currentLabel = LANGUAGE_OPTIONS.find(
+  const { i18n } = useTranslation();
+  const currentOption = LANGUAGE_OPTIONS.find(
     (opt) => opt.value === i18n.language,
-  )!.label;
+  )!;
 
   const filteredOptions = LANGUAGE_OPTIONS.filter(
     (opt) => opt.value !== i18n.language,
-  ).map((option) => ({
-    ...option,
-    label: t(option.label),
-  }));
+  );
 
   return (
     <div className={styles.container}>
@@ -26,7 +23,7 @@ const LanguageSelector = () => {
         options={filteredOptions}
         icon={<GlobalIcon width={16} height={16} />}
       >
-        {t(currentLabel)}
+        {currentOption.label}
       </Dropdown>
     </div>
   );

--- a/apps/web/src/shared/i18n/constants.ts
+++ b/apps/web/src/shared/i18n/constants.ts
@@ -1,8 +1,8 @@
 export const LANGUAGE_OPTIONS = [
-  { value: 'en', label: 'language.english' },
-  { value: 'ko', label: 'language.korean' },
-  { value: 'vi', label: 'language.vietnamese' },
-  { value: 'zh-CN', label: 'language.chinese' },
+  { value: 'en', label: 'English' },
+  { value: 'ko', label: '한국어' },
+  { value: 'vi', label: 'Tiếng Việt' },
+  { value: 'zh-CN', label: '中文' },
 ] as const;
 
 export type SupportedLanguage = (typeof LANGUAGE_OPTIONS)[number]['value'];

--- a/apps/web/src/shared/i18n/locales/en/common.json
+++ b/apps/web/src/shared/i18n/locales/en/common.json
@@ -4,12 +4,6 @@
     "confirm": "Confirm",
     "cancel": "Cancel"
   },
-  "language": {
-    "english": "English",
-    "korean": "Korean",
-    "vietnamese": "Vietnamese",
-    "chinese": "Chinese"
-  },
   "state": {
     "loading": "Loading..."
   },

--- a/apps/web/src/shared/i18n/locales/ko/common.json
+++ b/apps/web/src/shared/i18n/locales/ko/common.json
@@ -4,12 +4,6 @@
     "confirm": "확인",
     "cancel": "취소"
   },
-  "language": {
-    "english": "영어",
-    "korean": "한국어",
-    "vietnamese": "베트남어",
-    "chinese": "중국어"
-  },
   "state": {
     "loading": "로딩 중..."
   },

--- a/apps/web/src/shared/i18n/locales/vi/common.json
+++ b/apps/web/src/shared/i18n/locales/vi/common.json
@@ -4,12 +4,6 @@
     "confirm": "Xác nhận",
     "cancel": "Hủy"
   },
-  "language": {
-    "english": "Tiếng Anh",
-    "korean": "Tiếng Hàn",
-    "vietnamese": "Tiếng Việt",
-    "chinese": "Tiếng Trung"
-  },
   "state": {
     "loading": "Đang tải..."
   },

--- a/apps/web/src/shared/i18n/locales/zh-CN/common.json
+++ b/apps/web/src/shared/i18n/locales/zh-CN/common.json
@@ -4,12 +4,6 @@
     "confirm": "确认",
     "cancel": "取消"
   },
-  "language": {
-    "english": "英语",
-    "korean": "韩语",
-    "vietnamese": "越南语",
-    "chinese": "中文"
-  },
   "state": {
     "loading": "加载中..."
   },


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #308

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

- `common.json`에서 `language` 객체 제거
- `LANGUAGE_OPTIONS`의 `label`에 번역 키 대신 실제 표시 문자열(`English`, `한국어`, `Tiếng Việt`, `中文`)을 직접 정의
- LanguageSelector에서도 label 직접 사용

기존에는 `common.json`에서 `language` 값을 언어별 번역값으로 관리하고 있었어요.
하지만 이번에 `LanguageSelector`에서 언어명을 각 언어의 네이티브 표기(`English`, `한국어`, `Tiếng Việt`, `中文`)로 고정해서 보여주도록 변경하면서 동일한 `language` 객체가 각 `common.json`에 중복해서 들어가게 되었습니다.

  ```json
  "language": {
    "english": "English",
    "korean": "한국어",
    "vietnamese": "Tiếng Việt",
    "chinese": "中文"
  }
```

이 값들은 번역 데이터라기보다 고정 UI 라벨에 가깝다고 판단해 constants.ts로 분리했습니다.
추가로 기존 `LANGUAGE_OPTIONS`에서 번역 키를 label로 사용하고 있던 구조를 실제 표시 문자열을 직접 사용하도록 수정하며 `LanguageSelector`에서도 map()으로 옵션 배열을 한 번 더 변환하던 로직을 제거했어요.

<!--
(기재 내용 없을 경우 섹션 삭제)
더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

## 📸 Screenshot

https://github.com/user-attachments/assets/1ebe6dff-0353-4f04-b669-e418936c6aa2


<!--
(기재 내용 없을 경우 섹션 삭제)
UI 변경사항이 있는 경우 스크린샷을 첨부해주세요.
동적인 변화는 GIF로 첨부하면 더 좋습니다!
-->
