### PR TITLE
Fix(web): Todo 관련 Query 로직 수정

### DIFF
--- a/apps/web/src/entities/phase/queries/query-key.ts
+++ b/apps/web/src/entities/phase/queries/query-key.ts
@@ -15,15 +15,11 @@ export const PHASE_QUERY_KEY = {
     phaseId,
     getLocaleQueryKey(),
   ],
+  PHASE_ITEM_ROADMAP_ALL: () => [...PHASE_QUERY_KEY.ALL, 'phaseItemRoadmap'],
   PHASE_ITEM_ROADMAP: (phaseId: number) => [
     ...PHASE_QUERY_KEY.ALL,
     'phaseItemRoadmap',
     phaseId,
-    getLocaleQueryKey(),
-  ],
-  PHASE_ITEM_ROADMAP_ALL: () => [
-    ...PHASE_QUERY_KEY.ALL,
-    'phaseItemRoadmap',
     getLocaleQueryKey(),
   ],
 };

--- a/apps/web/src/widgets/layout/ui/todo-panel/todo-panel.tsx
+++ b/apps/web/src/widgets/layout/ui/todo-panel/todo-panel.tsx
@@ -34,19 +34,6 @@ const toggleCompleted = (
       : item,
   );
 
-const areAllTodosCompleted = (data?: ActionItemListResponse) => {
-  const allItems = [
-    ...(data?.visaActionItems ?? []),
-    ...(data?.careerActionItems ?? []),
-  ];
-
-  if (allItems.length === 0) {
-    return false;
-  }
-
-  return allItems.every((item) => item.completed);
-};
-
 const TodoPanel = () => {
   const navigate = useNavigate();
   const { t } = useTranslation('todo');
@@ -96,14 +83,6 @@ const TodoPanel = () => {
       }
     },
     onSuccess: () => {
-      const queryKey = TODO_QUERY_KEY.TODO_LIST();
-      const current =
-        queryClient.getQueryData<ActionItemListResponse>(queryKey);
-
-      if (!areAllTodosCompleted(current)) {
-        return;
-      }
-
       queryClient.invalidateQueries({
         queryKey: PHASE_QUERY_KEY.PHASE_ITEM_ROADMAP_ALL(),
       });

--- a/apps/web/src/widgets/roadmap/ui/action-required/action-required.tsx
+++ b/apps/web/src/widgets/roadmap/ui/action-required/action-required.tsx
@@ -7,8 +7,7 @@ import { TODO_MUTATION_OPTIONS } from '@features/todo/queries';
 import { PHASE_QUERY_KEY } from '@entities/phase/queries';
 import { TODO_QUERY_KEY } from '@entities/todo';
 import { components } from '@shared/types/schema';
-
-import { formatDate } from '../../../../shared/utils/date-formatter';
+import { formatDate } from '@shared/utils';
 
 import * as styles from './action-required.css';
 
@@ -41,13 +40,13 @@ const ActionRequired = ({
 }: ActionRequiredProps) => {
   const { t } = useTranslation('roadmap');
   const queryClient = useQueryClient();
-  const { mutate } = useMutation({
+  const { mutate, isPending, variables } = useMutation({
     ...TODO_MUTATION_OPTIONS.POST_TODO(),
-    onSuccess: () => {
-      queryClient.invalidateQueries({
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
         queryKey: TODO_QUERY_KEY.TODO_LIST(),
       });
-      queryClient.invalidateQueries({
+      await queryClient.invalidateQueries({
         queryKey: PHASE_QUERY_KEY.PHASE_ITEM_ROADMAP_ALL(),
       });
     },
@@ -97,7 +96,9 @@ const ActionRequired = ({
                 subTitle={item.description ?? ''}
                 dueDate={formatDate(item.deadline) ?? ''}
                 disabled={key === 'Done'}
-                isButtonDisabled={item.added}
+                isButtonDisabled={
+                  item.added || (isPending && variables === item.phaseActionId)
+                }
                 onSelect={() => handleSelect(item.phaseActionId)}
                 onTodoClick={() => handleTodoItem(item.phaseActionId)}
               />


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #311 

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

- Todo 완료시 Action Required -> Done 반영 로직 수정
- Todo 추가 네트워크 지연 시 클릭한 항목의 Todo 추가 버튼이 비동기 처리 동안 disabled 되도록 수정

## 👀 To Reviewer
기존 `Todo-Panel`에 여러 `Todo`가 들어갔을 때 모두 체크해야 `Action Required`에서 `Done`으로 이동되도록 구현 되어있었어요..
따라서 이 로직들을 전부 제거해서 모든 Todo가 아닌 `개별 TodoItem`이 모두 체크되면 `Done`으로 이동되도록 수정했습니다.

추가로 기존에 Todo 추가 버튼은 Todo가 추가되었을 때 `disabled` 처리되도록 구현 되어있었어요.
하지만 네트워크가 느릴 때는 Todo 추가 버튼을 연타하면 활성화 상태로 계속 서버에 요청을 보내게 되는 구조였어서 이를 비동기로 처리해서 서버에서 응답이 올때까지 disabled 되도록 수정했어요.

<!--
(기재 내용 없을 경우 섹션 삭제)
더 전달할 내용 혹은 리뷰에게 요청하는 내용을 작성해주세요.
-->

## 📸 Screenshot

https://github.com/user-attachments/assets/d78e2e65-c4cc-42ef-b42e-6a13ad357a31


https://github.com/user-attachments/assets/7fbab830-77af-442e-8214-ef849e6622f4


<!--
(기재 내용 없을 경우 섹션 삭제)
UI 변경사항이 있는 경우 스크린샷을 첨부해주세요.
동적인 변화는 GIF로 첨부하면 더 좋습니다!
-->
