### PR TITLE
Fix(web): 온보딩 Passport OCR 로직 수정

### DIFF
--- a/apps/web/src/shared/types/schema.d.ts
+++ b/apps/web/src/shared/types/schema.d.ts
@@ -592,6 +592,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1/members/completion': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 온보딩, 약관동의 여부 조회 */
+    get: operations['getMemberCompletionStatus'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/v1/job-postings/crawl': {
     parameters: {
       query?: never;
@@ -1135,212 +1152,24 @@ export interface components {
       message?: string;
       data?: components['schemas']['OcrPassportResponse'];
     };
+    /**
+     * @description 국가 코드 및 라벨
+     * @example {
+     *       "code": "south-korea",
+     *       "label": "South Korea"
+     *     }
+     */
+    LocalizedItemResponse: {
+      code?: string;
+      label?: string;
+    };
     OcrPassportResponse: {
       /**
        * @description Full Name
        * @example Hong Seungwon
        */
       fullName?: string;
-      /**
-       * @description 국가
-       * @example AFGHANISTAN
-       * @enum {string}
-       */
-      country?:
-        | 'Afghanistan'
-        | 'Albania'
-        | 'Algeria'
-        | 'Andorra'
-        | 'Angola'
-        | 'Antigua and Barbuda'
-        | 'Argentina'
-        | 'Armenia'
-        | 'Australia'
-        | 'Austria'
-        | 'Azerbaijan'
-        | 'Bahamas'
-        | 'Bahrain'
-        | 'Bangladesh'
-        | 'Barbados'
-        | 'Belarus'
-        | 'Belgium'
-        | 'Belize'
-        | 'Benin'
-        | 'Bhutan'
-        | 'Bolivia'
-        | 'Bosnia and Herzegovina'
-        | 'Botswana'
-        | 'Brazil'
-        | 'Brunei'
-        | 'Bulgaria'
-        | 'Burkina Faso'
-        | 'Burundi'
-        | 'Cabo Verde'
-        | 'Cambodia'
-        | 'Cameroon'
-        | 'Canada'
-        | 'Central African Republic'
-        | 'Chad'
-        | 'Chile'
-        | 'China'
-        | 'Colombia'
-        | 'Comoros'
-        | 'Congo'
-        | 'Democratic Republic of the Congo'
-        | 'Costa Rica'
-        | "Cote d'Ivoire"
-        | 'Croatia'
-        | 'Cuba'
-        | 'Cyprus'
-        | 'Czechia'
-        | 'Denmark'
-        | 'Djibouti'
-        | 'Dominica'
-        | 'Dominican Republic'
-        | 'Ecuador'
-        | 'Egypt'
-        | 'El Salvador'
-        | 'Equatorial Guinea'
-        | 'Eritrea'
-        | 'Estonia'
-        | 'Eswatini'
-        | 'Ethiopia'
-        | 'Fiji'
-        | 'Finland'
-        | 'France'
-        | 'Gabon'
-        | 'Gambia'
-        | 'Georgia'
-        | 'Germany'
-        | 'Ghana'
-        | 'Greece'
-        | 'Grenada'
-        | 'Guatemala'
-        | 'Guinea'
-        | 'Guinea-Bissau'
-        | 'Guyana'
-        | 'Haiti'
-        | 'Honduras'
-        | 'Hungary'
-        | 'Iceland'
-        | 'India'
-        | 'Indonesia'
-        | 'Iran'
-        | 'Iraq'
-        | 'Ireland'
-        | 'Israel'
-        | 'Italy'
-        | 'Jamaica'
-        | 'Japan'
-        | 'Jordan'
-        | 'Kazakhstan'
-        | 'Kenya'
-        | 'Kiribati'
-        | 'Kuwait'
-        | 'Kyrgyzstan'
-        | 'Laos'
-        | 'Latvia'
-        | 'Lebanon'
-        | 'Lesotho'
-        | 'Liberia'
-        | 'Libya'
-        | 'Liechtenstein'
-        | 'Lithuania'
-        | 'Luxembourg'
-        | 'Madagascar'
-        | 'Malawi'
-        | 'Malaysia'
-        | 'Maldives'
-        | 'Mali'
-        | 'Malta'
-        | 'Marshall Islands'
-        | 'Mauritania'
-        | 'Mauritius'
-        | 'Mexico'
-        | 'Micronesia'
-        | 'Moldova'
-        | 'Monaco'
-        | 'Mongolia'
-        | 'Montenegro'
-        | 'Morocco'
-        | 'Mozambique'
-        | 'Myanmar'
-        | 'Namibia'
-        | 'Nauru'
-        | 'Nepal'
-        | 'Netherlands'
-        | 'New Zealand'
-        | 'Nicaragua'
-        | 'Niger'
-        | 'Nigeria'
-        | 'North Macedonia'
-        | 'Norway'
-        | 'Oman'
-        | 'Pakistan'
-        | 'Palau'
-        | 'Panama'
-        | 'Papua New Guinea'
-        | 'Paraguay'
-        | 'Peru'
-        | 'Philippines'
-        | 'Poland'
-        | 'Portugal'
-        | 'Qatar'
-        | 'Romania'
-        | 'Russia'
-        | 'Rwanda'
-        | 'Saint Kitts and Nevis'
-        | 'Saint Lucia'
-        | 'Saint Vincent and the Grenadines'
-        | 'Samoa'
-        | 'San Marino'
-        | 'Sao Tome and Principe'
-        | 'Saudi Arabia'
-        | 'Senegal'
-        | 'Serbia'
-        | 'Seychelles'
-        | 'Sierra Leone'
-        | 'Singapore'
-        | 'Slovakia'
-        | 'Slovenia'
-        | 'Solomon Islands'
-        | 'Somalia'
-        | 'South Africa'
-        | 'South Korea'
-        | 'South Sudan'
-        | 'Spain'
-        | 'Sri Lanka'
-        | 'Sudan'
-        | 'Suriname'
-        | 'Sweden'
-        | 'Switzerland'
-        | 'Syria'
-        | 'Taiwan'
-        | 'Tajikistan'
-        | 'Tanzania'
-        | 'Thailand'
-        | 'Timor-Leste'
-        | 'Togo'
-        | 'Tonga'
-        | 'Trinidad and Tobago'
-        | 'Tunisia'
-        | 'Turkey'
-        | 'Turkmenistan'
-        | 'Tuvalu'
-        | 'Uganda'
-        | 'Ukraine'
-        | 'United Arab Emirates'
-        | 'United Kingdom'
-        | 'United States'
-        | 'Uruguay'
-        | 'Uzbekistan'
-        | 'Vanuatu'
-        | 'Vatican City'
-        | 'Venezuela'
-        | 'Vietnam'
-        | 'Yemen'
-        | 'Zambia'
-        | 'Zimbabwe';
+      country?: components['schemas']['LocalizedItemResponse'];
       /**
        * Format: date
        * @description 생년월일
@@ -1663,10 +1492,6 @@ export interface components {
       message?: string;
       data?: components['schemas']['OnboardUniversitiesResponse'];
     };
-    LocalizedItemResponse: {
-      code?: string;
-      label?: string;
-    };
     OnboardUniversitiesResponse: {
       universities?: components['schemas']['LocalizedItemResponse'][];
     };
@@ -1907,16 +1732,21 @@ export interface components {
        * @description 졸업일
        */
       graduationDate?: string;
+    };
+    BaseResponseMemberCompletionResponse: {
       /**
-       * @description 온보딩 여부
-       * @example true
+       * Format: int32
+       * @example 200
        */
+      code?: number;
+      message?: string;
+      data?: components['schemas']['MemberCompletionResponse'];
+    };
+    MemberCompletionResponse: {
+      /** @description 온보딩 여부 */
       onboardingRequired?: boolean;
-      /**
-       * @description 약관 동의 여부
-       * @example true
-       */
-      agreedTerm?: boolean;
+      /** @description 약관 동의 여부 */
+      agreeTerm?: boolean;
     };
     BaseResponseJobPostingCrawlListResponse: {
       /**
@@ -4064,6 +3894,77 @@ export interface operations {
         };
         content: {
           '*/*': components['schemas']['BaseResponseMemberStatusResponse'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  getMemberCompletionStatus: {
+    parameters: {
+      query?: never;
+      header?: {
+        /** @description Preferred language code (e.g., en, ko, zh-CN, vi) */
+        'X-Preferred-Language'?: string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponseMemberCompletionResponse'];
         };
       };
       400: {

--- a/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
+++ b/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
@@ -36,10 +36,10 @@ const IdentityVisaVerification = () => {
     ...ONBOARDING_MUTATION_OPTIONS.POST_OCR_PASSPORT(),
     onSuccess: (data) => {
       setValue('name', data.data?.fullName ?? '');
-      const normalizedCountryCode = (data.data?.country ?? '')
-        .toLowerCase()
-        .replace(/\s+/g, '-');
-      setValue('countryCode', normalizedCountryCode);
+      setValue(
+        'countryCode',
+        (data.data?.country ?? '').toLowerCase().replace(/\s+/g, '-'),
+      );
       setValue('birthDate', data.data?.birthDate ?? '');
     },
   });

--- a/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
+++ b/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
@@ -36,10 +36,7 @@ const IdentityVisaVerification = () => {
     ...ONBOARDING_MUTATION_OPTIONS.POST_OCR_PASSPORT(),
     onSuccess: (data) => {
       setValue('name', data.data?.fullName ?? '');
-      setValue(
-        'countryCode',
-        (data.data?.country ?? '').toLowerCase().replace(/\s+/g, '-'),
-      );
+      setValue('countryCode', data.data?.country?.code ?? '');
       setValue('birthDate', data.data?.birthDate ?? '');
     },
   });

--- a/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
+++ b/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
@@ -36,7 +36,10 @@ const IdentityVisaVerification = () => {
     ...ONBOARDING_MUTATION_OPTIONS.POST_OCR_PASSPORT(),
     onSuccess: (data) => {
       setValue('name', data.data?.fullName ?? '');
-      setValue('countryCode', (data.data?.country ?? '').toLowerCase());
+      const normalizedCountryCode = (data.data?.country ?? '')
+        .toLowerCase()
+        .replace(/\s+/g, '-');
+      setValue('countryCode', normalizedCountryCode);
       setValue('birthDate', data.data?.birthDate ?? '');
     },
   });

--- a/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
+++ b/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification.tsx
@@ -36,7 +36,7 @@ const IdentityVisaVerification = () => {
     ...ONBOARDING_MUTATION_OPTIONS.POST_OCR_PASSPORT(),
     onSuccess: (data) => {
       setValue('name', data.data?.fullName ?? '');
-      setValue('countryCode', data.data?.country ?? '');
+      setValue('countryCode', (data.data?.country ?? '').toLowerCase());
       setValue('birthDate', data.data?.birthDate ?? '');
     },
   });

--- a/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/ui/user-info-form-section/user-info-form-section.tsx
+++ b/apps/web/src/widgets/onboarding/ui/step/identity-visaVerification/ui/user-info-form-section/user-info-form-section.tsx
@@ -11,7 +11,7 @@ import { COUNTRY_LIST_QUERY_OPTIONS } from '@entities/onboarding';
 
 import * as styles from './user-info-form-section.css';
 
-const MAX_LENGTH = 20;
+const MAX_LENGTH = 40;
 
 const UserInfoFormSection = () => {
   const { t } = useTranslation('onboarding');


### PR DESCRIPTION
## 📌 Summary
> - #310 

## 📚 Tasks
- 여권 OCR 응답의 country 값을 countryCode 폼 필드에 올바르게 매핑되도록 수정
- 이름 Input 글자 수 제한 기존 20자에서 40자로 수정(기획파트와 논의 완료)

## 👀 To Reviewer
여권 OCR은 국가명을 "South Korea" 형태로 내려주는데 country list code는 "south-korea" 형식입니다. 
그래서 `.replace(/\s+/g, '-')`로 공백을 하이픈으로 변환해서 해결했습니다. 

## 📸 Screenshot
https://github.com/user-attachments/assets/670204ce-59e3-4fb0-b73f-d0c42cab3368

