### PR TITLE
Refactor(web): 로더 로직 개선

### DIFF
--- a/apps/web/src/entities/user/api/get-user-completion.ts
+++ b/apps/web/src/entities/user/api/get-user-completion.ts
@@ -1,0 +1,9 @@
+import { END_POINT, GetUserCompletion } from '@entities/user/model';
+import { api } from '@shared/apis/configs/instance';
+
+export const getUserCompletion = async () => {
+  const response = await api
+    .get(END_POINT.USER.GET_USER_COMPLETION)
+    .json<GetUserCompletion>();
+  return response.data;
+};

--- a/apps/web/src/entities/user/api/index.ts
+++ b/apps/web/src/entities/user/api/index.ts
@@ -1,3 +1,4 @@
+export { getUserCompletion } from './get-user-completion';
 export { getUserInfo } from './get-user-info';
 export { getUserMyPage } from './get-user-mypage';
 export { getUserStatus } from './get-user-status';

--- a/apps/web/src/entities/user/model/end_point.ts
+++ b/apps/web/src/entities/user/model/end_point.ts
@@ -2,6 +2,7 @@ export const END_POINT = {
   USER: {
     GET_USER_INFO: 'api/v1/members/me',
     GET_USER_STATUS: 'api/v1/members/me/status',
+    GET_USER_COMPLETION: 'api/v1/members/completion',
     GET_MY_PAGE_INFO: 'api/v1/members/mypage',
   },
 };

--- a/apps/web/src/entities/user/model/index.ts
+++ b/apps/web/src/entities/user/model/index.ts
@@ -1,4 +1,7 @@
 export { END_POINT } from './end_point';
-export type { GetUserStatusResponse } from './types';
-export type { GetUserInfoResponse } from './types';
-export type { GetUserMyPageResponse } from './types';
+export type {
+  GetUserCompletion,
+  GetUserInfoResponse,
+  GetUserMyPageResponse,
+  GetUserStatusResponse,
+} from './types';

--- a/apps/web/src/entities/user/model/types.ts
+++ b/apps/web/src/entities/user/model/types.ts
@@ -4,5 +4,7 @@ export type GetUserInfoResponse =
   paths['/api/v1/members/me']['get']['responses']['200']['content']['*/*'];
 export type GetUserStatusResponse =
   paths['/api/v1/members/me/status']['get']['responses']['200']['content']['*/*'];
+export type GetUserCompletion =
+  paths['/api/v1/members/completion']['get']['responses']['200']['content']['*/*'];
 export type GetUserMyPageResponse =
   paths['/api/v1/members/mypage']['get']['responses']['200']['content']['*/*'];

--- a/apps/web/src/entities/user/queries/queries.ts
+++ b/apps/web/src/entities/user/queries/queries.ts
@@ -1,6 +1,11 @@
 import { queryOptions } from '@tanstack/react-query';
 
-import { getUserInfo, getUserMyPage, getUserStatus } from '@entities/user/api';
+import {
+  getUserCompletion,
+  getUserInfo,
+  getUserMyPage,
+  getUserStatus,
+} from '@entities/user/api';
 import { USER_QUERY_KEY } from '@entities/user/queries';
 
 export const USER_QUERY_OPTIONS = {
@@ -14,6 +19,14 @@ export const USER_QUERY_OPTIONS = {
     return queryOptions({
       queryKey: USER_QUERY_KEY.USER_STATUS(),
       queryFn: getUserStatus,
+    });
+  },
+  GET_USER_COMPLETION: () => {
+    return queryOptions({
+      queryKey: USER_QUERY_KEY.USER_COMPLETION(),
+      queryFn: getUserCompletion,
+      // staleTime: Infinity,
+      // gcTime: Infinity,
     });
   },
   GET_MY_PAGE_INFO: () => {

--- a/apps/web/src/entities/user/queries/queries.ts
+++ b/apps/web/src/entities/user/queries/queries.ts
@@ -25,8 +25,8 @@ export const USER_QUERY_OPTIONS = {
     return queryOptions({
       queryKey: USER_QUERY_KEY.USER_COMPLETION(),
       queryFn: getUserCompletion,
-      // staleTime: Infinity,
-      // gcTime: Infinity,
+      staleTime: Infinity,
+      gcTime: Infinity,
     });
   },
   GET_MY_PAGE_INFO: () => {

--- a/apps/web/src/entities/user/queries/query-key.ts
+++ b/apps/web/src/entities/user/queries/query-key.ts
@@ -4,5 +4,6 @@ export const USER_QUERY_KEY = {
   ALL: ['user'],
   USER_INFO: () => [...USER_QUERY_KEY.ALL, 'userInfo', getLocaleQueryKey()],
   USER_STATUS: () => [...USER_QUERY_KEY.ALL, 'status', getLocaleQueryKey()],
+  USER_COMPLETION: () => [...USER_QUERY_KEY.ALL, 'completion'],
   USER_MY_PAGE: () => [...USER_QUERY_KEY.ALL, 'myPage', getLocaleQueryKey()],
 };

--- a/apps/web/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/web/src/pages/onboarding/onboarding-page.tsx
@@ -13,7 +13,6 @@ import {
 import CareerPreference from '@widgets/onboarding/ui/step/career-preference/career-preference';
 import IdentityVisaVerification from '@widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification';
 import type { PostOnboardingForm } from '@features/onboarding';
-import { postOnboardingForm } from '@features/onboarding';
 import { ONBOARDING_MUTATION_OPTIONS } from '@features/onboarding/queries';
 import {
   convertFormToRequest,
@@ -105,10 +104,10 @@ const OnboardingPage = () => {
   });
 
   const { mutate: submitOnboarding } = useMutation({
-    mutationFn: postOnboardingForm,
+    ...ONBOARDING_MUTATION_OPTIONS.POST_ONBOARDING_FORM(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({
-        queryKey: USER_QUERY_KEY.USER_STATUS(),
+      await queryClient.refetchQueries({
+        queryKey: USER_QUERY_KEY.USER_COMPLETION(),
       });
       // 온보딩 성공 후 로드맵 생성 API 호출
       generateRoadmap();

--- a/apps/web/src/pages/terms-agreement/terms-agreement-page.tsx
+++ b/apps/web/src/pages/terms-agreement/terms-agreement-page.tsx
@@ -5,6 +5,8 @@ import { useNavigate } from 'react-router';
 
 import { AccordionList, useTermsCheck } from '@widgets/terms-agreement';
 import { Term, TERMS_QUERY_OPTIONS } from '@entities/terms';
+import { USER_QUERY_KEY } from '@entities/user/queries';
+import { queryClient } from '@shared/apis/providers/query-client';
 import { ROUTE_PATH } from '@shared/router';
 
 import * as styles from './terms-agreement-page.css';
@@ -19,7 +21,10 @@ const TermsAgreementPage = () => {
 
   const { mutate: submitTerms } = useMutation({
     ...TERMS_QUERY_OPTIONS.POST_TERM_AGREEMENTS(),
-    onSuccess: () => {
+    onSuccess: async () => {
+      await queryClient.refetchQueries({
+        queryKey: USER_QUERY_KEY.USER_COMPLETION(),
+      });
       navigate(ROUTE_PATH.ONBOARDING);
     },
   });

--- a/apps/web/src/shared/router/loader.ts
+++ b/apps/web/src/shared/router/loader.ts
@@ -3,9 +3,7 @@ import { type LoaderFunctionArgs, redirect } from 'react-router';
 import { USER_QUERY_OPTIONS } from '@entities/user/queries';
 import { queryClient } from '@shared/apis/providers/query-client';
 import { authService } from '@shared/auth/auth-service';
-import { HTTP_STATUS_CODE } from '@shared/constants/HTTP_STATUS_CODE';
 import { ROUTE_PATH } from '@shared/router';
-import { isHttpError } from '@shared/utils/http-error';
 
 export const requireAuth = () => {
   if (!authService.isAuthenticated()) {
@@ -22,35 +20,23 @@ export const guestOnlyLoader = ({ request }: LoaderFunctionArgs) => {
   return null;
 };
 
-// TODO: 로더 로직 개선 필요
 export const appRouteLoader = async () => {
   requireAuth();
 
-  try {
-    const userStatus = await queryClient.ensureQueryData(
-      USER_QUERY_OPTIONS.GET_USER_STATUS(),
-    );
+  const userCompletion = await queryClient.ensureQueryData(
+    USER_QUERY_OPTIONS.GET_USER_COMPLETION(),
+  );
 
-    if (!userStatus) {
-      return;
-    }
+  if (!userCompletion) {
+    return;
+  }
 
-    if (!userStatus.agreedTerm) {
-      throw redirect(ROUTE_PATH.TERMSAGREEMENT);
-    }
+  if (!userCompletion.agreeTerm) {
+    throw redirect(ROUTE_PATH.TERMSAGREEMENT);
+  }
 
-    if (userStatus.onboardingRequired) {
-      throw redirect(ROUTE_PATH.ONBOARDING);
-    }
-  } catch (error) {
-    if (
-      isHttpError(error) &&
-      error.response?.status === HTTP_STATUS_CODE.FORBIDDEN
-    ) {
-      throw redirect(ROUTE_PATH.TERMSAGREEMENT);
-    }
-
-    throw error;
+  if (userCompletion.onboardingRequired) {
+    throw redirect(ROUTE_PATH.ONBOARDING);
   }
 
   return null;
@@ -59,35 +45,20 @@ export const appRouteLoader = async () => {
 export const termsGuardLoader = async () => {
   requireAuth();
 
-  try {
-    const userStatus = await queryClient.ensureQueryData(
-      USER_QUERY_OPTIONS.GET_USER_STATUS(),
-    );
+  const userCompletion = await queryClient.ensureQueryData(
+    USER_QUERY_OPTIONS.GET_USER_COMPLETION(),
+  );
 
-    if (!userStatus) {
-      return;
-    }
+  if (!userCompletion) {
+    return;
+  }
 
-    if (!userStatus.agreedTerm) {
-      return null;
-    }
+  const redirectUrl = userCompletion.onboardingRequired
+    ? ROUTE_PATH.ONBOARDING
+    : ROUTE_PATH.DASHBOARD;
 
-    const redirectUrl = userStatus.onboardingRequired
-      ? ROUTE_PATH.ONBOARDING
-      : ROUTE_PATH.DASHBOARD;
-
-    if (userStatus.agreedTerm) {
-      throw redirect(redirectUrl);
-    }
-  } catch (error) {
-    if (
-      isHttpError(error) &&
-      error.response?.status === HTTP_STATUS_CODE.FORBIDDEN
-    ) {
-      throw redirect(ROUTE_PATH.ONBOARDING);
-    }
-
-    throw error;
+  if (userCompletion.agreeTerm) {
+    throw redirect(redirectUrl);
   }
 
   return null;
@@ -96,27 +67,20 @@ export const termsGuardLoader = async () => {
 export const onboardingGuardLoader = async () => {
   requireAuth();
 
-  try {
-    const userStatus = await queryClient.ensureQueryData(
-      USER_QUERY_OPTIONS.GET_USER_STATUS(),
-    );
+  const userCompletion = await queryClient.ensureQueryData(
+    USER_QUERY_OPTIONS.GET_USER_COMPLETION(),
+  );
 
-    if (!userStatus) {
-      return;
-    }
+  if (!userCompletion) {
+    return;
+  }
 
-    if (userStatus.onboardingRequired === false) {
-      throw redirect(ROUTE_PATH.DASHBOARD);
-    }
-  } catch (error) {
-    if (
-      isHttpError(error) &&
-      error.response?.status === HTTP_STATUS_CODE.FORBIDDEN
-    ) {
-      return null;
-    }
+  if (!userCompletion.agreeTerm) {
+    throw redirect(ROUTE_PATH.TERMSAGREEMENT);
+  }
 
-    throw error;
+  if (!userCompletion.onboardingRequired) {
+    throw redirect(ROUTE_PATH.DASHBOARD);
   }
 
   return null;

--- a/apps/web/src/shared/router/router.tsx
+++ b/apps/web/src/shared/router/router.tsx
@@ -7,7 +7,12 @@ import {
   OnboardingPage,
   TermsAgreementPage,
 } from '@shared/router/lazy';
-import { appRouteLoader, guestOnlyLoader } from '@shared/router/loader';
+import {
+  appRouteLoader,
+  guestOnlyLoader,
+  onboardingGuardLoader,
+  termsGuardLoader,
+} from '@shared/router/loader';
 import OnboardingRouteLayout from '@shared/router/onboarding-route-layout';
 import {
   protectedAppRoutes,
@@ -24,15 +29,14 @@ export const router = createBrowserRouter([
         loader: guestOnlyLoader,
         Component: LoginPage,
       },
-      // TODO: 로더 개선 필요
       {
         path: ROUTE_PATH.TERMSAGREEMENT,
-        // loader: termsGuardLoader,
+        loader: termsGuardLoader,
         Component: TermsAgreementPage,
       },
       {
         path: ROUTE_PATH.ONBOARDING,
-        // loader: onboardingGuardLoader,
+        loader: onboardingGuardLoader,
         Component: OnboardingPage,
       },
     ],

--- a/apps/web/src/shared/types/schema.d.ts
+++ b/apps/web/src/shared/types/schema.d.ts
@@ -592,6 +592,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1/members/completion': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** 온보딩, 약관동의 여부 조회 */
+    get: operations['getMemberCompletionStatus'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/v1/job-postings/crawl': {
     parameters: {
       query?: never;
@@ -1907,16 +1924,21 @@ export interface components {
        * @description 졸업일
        */
       graduationDate?: string;
+    };
+    BaseResponseMemberCompletionResponse: {
       /**
-       * @description 온보딩 여부
-       * @example true
+       * Format: int32
+       * @example 200
        */
+      code?: number;
+      message?: string;
+      data?: components['schemas']['MemberCompletionResponse'];
+    };
+    MemberCompletionResponse: {
+      /** @description 온보딩 여부 */
       onboardingRequired?: boolean;
-      /**
-       * @description 약관 동의 여부
-       * @example true
-       */
-      agreedTerm?: boolean;
+      /** @description 약관 동의 여부 */
+      agreeTerm?: boolean;
     };
     BaseResponseJobPostingCrawlListResponse: {
       /**
@@ -4064,6 +4086,77 @@ export interface operations {
         };
         content: {
           '*/*': components['schemas']['BaseResponseMemberStatusResponse'];
+        };
+      };
+      400: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      401: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      403: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      405: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      500: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+    };
+  };
+  getMemberCompletionStatus: {
+    parameters: {
+      query?: never;
+      header?: {
+        /** @description Preferred language code (e.g., en, ko, zh-CN, vi) */
+        'X-Preferred-Language'?: string;
+      };
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description OK */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          '*/*': components['schemas']['BaseResponseMemberCompletionResponse'];
         };
       };
       400: {


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #315 

## 📚 Tasks

### 로더 로직 개선

**기존**: 온보딩 이후 서비스 페이지(roadmap, dashboard, fit-analysis, mypage) 접근 가능
**1차 스프린트**: 약관동의, 온보딩 이후 서비스 페이지 접근 가능

약관동의가 끝나야만 온보딩으로 이동이 가능하고,
온보딩이 끝나야만 서비스 페이지로 이동이 가능하게 로더 로직을 개선했어요.

약관동의 여부, 온보딩 여부를 반환하는 유저 완료 상태 조회 API(`/api/v1/members/completion`)가 새로 만들어졌어요.
(정연님 최고)

약관동의 제출, 온보딩 제출 이후 해당 API를 refetch하는 방식으로 구현했어요.
