### PR TITLE
Refactor(web): 온보딩 페이지 훅 분리 개선

### DIFF
--- a/apps/web/src/pages/onboarding/hooks/useOnboardingStepValidation.ts
+++ b/apps/web/src/pages/onboarding/hooks/useOnboardingStepValidation.ts
@@ -1,0 +1,62 @@
+import { type UseFormReturn, useWatch } from 'react-hook-form';
+
+import {
+  FUNNEL_STEPS,
+  getRequiredFieldsForStep,
+  hasAllRequiredFieldValues,
+  type OnboardingForm,
+} from '@entities/onboarding';
+
+const MAX_PERSONAL_BACKGROUND_LENGTH = 1000;
+
+interface useOnbardingStepValidationProps {
+  form: UseFormReturn<OnboardingForm>;
+  currentStepIndex: number;
+}
+
+const useOnboardingStepValidation = ({
+  form,
+  currentStepIndex,
+}: useOnbardingStepValidationProps) => {
+  const requiredFields = getRequiredFieldsForStep(currentStepIndex);
+
+  // 현재 단계의 필수 필드만 감시
+  const watchedRequiredFields = useWatch({
+    control: form.control,
+    name: requiredFields,
+  });
+
+  // 전체 폼 값 감시
+  const allFormValues = useWatch({
+    control: form.control,
+  }) as OnboardingForm;
+
+  // 길이 체크
+  const personalBackground = useWatch({
+    control: form.control,
+    name: 'personalBackground',
+  });
+  const isPersonalBackgroundOverLimit =
+    currentStepIndex === FUNNEL_STEPS.length - 1 &&
+    (personalBackground?.length || 0) > MAX_PERSONAL_BACKGROUND_LENGTH;
+
+  // 모든 필드 존재 체크
+  const hasAllRequiredValues = hasAllRequiredFieldValues(
+    { ...allFormValues, ...watchedRequiredFields } as OnboardingForm,
+    requiredFields,
+  );
+
+  const hasStepErrors = requiredFields.some((fieldName) =>
+    Boolean(form.formState.errors[fieldName]),
+  );
+
+  const isNextDisabled =
+    form.formState.isLoading ||
+    !hasAllRequiredValues ||
+    hasStepErrors ||
+    isPersonalBackgroundOverLimit;
+
+  return { requiredFields, isNextDisabled };
+};
+
+export default useOnboardingStepValidation;

--- a/apps/web/src/pages/onboarding/hooks/useOnboardingStepValidation.ts
+++ b/apps/web/src/pages/onboarding/hooks/useOnboardingStepValidation.ts
@@ -1,13 +1,12 @@
 import { type UseFormReturn, useWatch } from 'react-hook-form';
 
 import {
+  FIELD_MAX_LENGTHS,
   FUNNEL_STEPS,
   getRequiredFieldsForStep,
   hasAllRequiredFieldValues,
   type OnboardingForm,
 } from '@entities/onboarding';
-
-const MAX_PERSONAL_BACKGROUND_LENGTH = 1000;
 
 interface UseOnboardingStepValidationProps {
   form: UseFormReturn<OnboardingForm>;
@@ -38,7 +37,7 @@ const useOnboardingStepValidation = ({
   });
   const isPersonalBackgroundOverLimit =
     currentStepIndex === FUNNEL_STEPS.length - 1 &&
-    (personalBackground?.length || 0) > MAX_PERSONAL_BACKGROUND_LENGTH;
+    (personalBackground?.length || 0) > FIELD_MAX_LENGTHS.PERSONAL_BACKGROUND;
 
   // 모든 필드 존재 체크
   const hasAllRequiredValues = hasAllRequiredFieldValues(

--- a/apps/web/src/pages/onboarding/hooks/useOnboardingStepValidation.ts
+++ b/apps/web/src/pages/onboarding/hooks/useOnboardingStepValidation.ts
@@ -9,7 +9,7 @@ import {
 
 const MAX_PERSONAL_BACKGROUND_LENGTH = 1000;
 
-interface useOnbardingStepValidationProps {
+interface UseOnboardingStepValidationProps {
   form: UseFormReturn<OnboardingForm>;
   currentStepIndex: number;
 }
@@ -17,7 +17,7 @@ interface useOnbardingStepValidationProps {
 const useOnboardingStepValidation = ({
   form,
   currentStepIndex,
-}: useOnbardingStepValidationProps) => {
+}: UseOnboardingStepValidationProps) => {
   const requiredFields = getRequiredFieldsForStep(currentStepIndex);
 
   // 현재 단계의 필수 필드만 감시

--- a/apps/web/src/pages/onboarding/hooks/useOnboardingSubmit.ts
+++ b/apps/web/src/pages/onboarding/hooks/useOnboardingSubmit.ts
@@ -33,8 +33,12 @@ const useOnboardingSubmit = ({ goToNextStep }: UseOnboardingSubmitProps) => {
       generateRoadmap();
       goToNextStep();
     },
-    onError: (error) => {
-      setError(error instanceof Error ? error : new Error('온보딩 제출 실패'));
+    onError: (submitError) => {
+      setError(
+        submitError instanceof Error
+          ? submitError
+          : new Error('온보딩 제출 실패'),
+      );
     },
   });
 

--- a/apps/web/src/pages/onboarding/hooks/useOnboardingSubmit.ts
+++ b/apps/web/src/pages/onboarding/hooks/useOnboardingSubmit.ts
@@ -1,0 +1,44 @@
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { ONBOARDING_MUTATION_OPTIONS } from '@features/onboarding';
+import { USER_QUERY_KEY } from '@entities/user/queries';
+
+interface UseOnboardingSubmitProps {
+  goToNextStep: () => void;
+}
+
+const useOnboardingSubmit = ({ goToNextStep }: UseOnboardingSubmitProps) => {
+  const queryClient = useQueryClient();
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (error) {
+      throw error;
+    }
+  }, [error]);
+
+  // 로드맵 생성 mutation
+  const { mutate: generateRoadmap } = useMutation({
+    ...ONBOARDING_MUTATION_OPTIONS.POST_AI_ROADMAP(),
+  });
+
+  const { mutate: submitOnboarding } = useMutation({
+    ...ONBOARDING_MUTATION_OPTIONS.POST_ONBOARDING_FORM(),
+    onSuccess: async () => {
+      await queryClient.refetchQueries({
+        queryKey: USER_QUERY_KEY.USER_COMPLETION(),
+      });
+      // 온보딩 성공 후 로드맵 생성 API 호출
+      generateRoadmap();
+      goToNextStep();
+    },
+    onError: (error) => {
+      setError(error instanceof Error ? error : new Error('온보딩 제출 실패'));
+    },
+  });
+
+  return { submitOnboarding };
+};
+
+export default useOnboardingSubmit;

--- a/apps/web/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/web/src/pages/onboarding/onboarding-page.tsx
@@ -2,14 +2,14 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import {
+  CareerPreference,
   createStepData,
   EducationStep,
+  IdentityVisaVerification,
   LanguageSkillStep,
   OnboardingStepLayout,
   PersonalBackgroundStep,
 } from '@widgets/onboarding';
-import CareerPreference from '@widgets/onboarding/ui/step/career-preference/career-preference';
-import IdentityVisaVerification from '@widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification';
 import type { PostOnboardingForm } from '@features/onboarding';
 import {
   convertFormToRequest,

--- a/apps/web/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/web/src/pages/onboarding/onboarding-page.tsx
@@ -1,5 +1,3 @@
-import { useEffect, useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
@@ -13,24 +11,21 @@ import {
 import CareerPreference from '@widgets/onboarding/ui/step/career-preference/career-preference';
 import IdentityVisaVerification from '@widgets/onboarding/ui/step/identity-visaVerification/identity-visaVerification';
 import type { PostOnboardingForm } from '@features/onboarding';
-import { ONBOARDING_MUTATION_OPTIONS } from '@features/onboarding/queries';
 import {
   convertFormToRequest,
   DEFAULT_ONBOARDING_FORM,
   FUNNEL_STEPS,
   OnboardingForm,
 } from '@entities/onboarding';
-import { USER_QUERY_KEY } from '@entities/user/queries';
 import useFunnel from '@shared/hooks/usefunnel';
 
 import useOnboardingStepValidation from './hooks/useOnboardingStepValidation';
+import useOnboardingSubmit from './hooks/useOnboardingSubmit';
 
 const OnboardingPage = () => {
   const { t } = useTranslation('onboarding');
-  const queryClient = useQueryClient();
   const { Funnel, Step, goToNextStep, goToPrevStep, currentStepIndex } =
     useFunnel(FUNNEL_STEPS, '/');
-  const [error, setError] = useState<Error | null>(null);
 
   const form = useForm<OnboardingForm>({
     mode: 'onChange',
@@ -43,11 +38,7 @@ const OnboardingPage = () => {
     currentStepIndex,
   });
 
-  useEffect(() => {
-    if (error) {
-      throw error;
-    }
-  }, [error]);
+  const { submitOnboarding } = useOnboardingSubmit({ goToNextStep });
 
   const steps = createStepData(
     [
@@ -63,26 +54,6 @@ const OnboardingPage = () => {
   const handleBack = () => {
     goToPrevStep();
   };
-
-  // 로드맵 생성 mutation
-  const { mutate: generateRoadmap } = useMutation({
-    ...ONBOARDING_MUTATION_OPTIONS.POST_AI_ROADMAP(),
-  });
-
-  const { mutate: submitOnboarding } = useMutation({
-    ...ONBOARDING_MUTATION_OPTIONS.POST_ONBOARDING_FORM(),
-    onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: USER_QUERY_KEY.USER_COMPLETION(),
-      });
-      // 온보딩 성공 후 로드맵 생성 API 호출
-      generateRoadmap();
-      goToNextStep();
-    },
-    onError: (error) => {
-      setError(error instanceof Error ? error : new Error('온보딩 제출 실패'));
-    },
-  });
 
   const handleNext = async () => {
     const isValid = await form.trigger(requiredFields);

--- a/apps/web/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/web/src/pages/onboarding/onboarding-page.tsx
@@ -18,12 +18,12 @@ import {
   convertFormToRequest,
   DEFAULT_ONBOARDING_FORM,
   FUNNEL_STEPS,
-  getRequiredFieldsForStep,
-  hasAllRequiredFieldValues,
   OnboardingForm,
 } from '@entities/onboarding';
 import { USER_QUERY_KEY } from '@entities/user/queries';
 import useFunnel from '@shared/hooks/usefunnel';
+
+import useOnboardingStepValidation from './hooks/useOnboardingStepValidation';
 
 const OnboardingPage = () => {
   const { t } = useTranslation('onboarding');
@@ -38,44 +38,10 @@ const OnboardingPage = () => {
     defaultValues: DEFAULT_ONBOARDING_FORM,
   });
 
-  // 버튼 비활성화 로직
-  const requiredFields = getRequiredFieldsForStep(currentStepIndex);
-
-  // 현재 단계의 필수 필드만 감시
-  const watchedRequiredFields = useWatch({
-    control: form.control,
-    name: requiredFields,
+  const { requiredFields, isNextDisabled } = useOnboardingStepValidation({
+    form,
+    currentStepIndex,
   });
-
-  // 전체 폼 값 감시
-  const allFormValues = useWatch({
-    control: form.control,
-  }) as OnboardingForm;
-
-  // 길이 체크
-  const personalBackground = useWatch({
-    control: form.control,
-    name: 'personalBackground',
-  });
-  const isPersonalBackgroundOverLimit =
-    currentStepIndex === FUNNEL_STEPS.length - 1 &&
-    (personalBackground?.length || 0) > 1000;
-
-  // 모든 필드 존재 체크
-  const hasAllRequiredValues = hasAllRequiredFieldValues(
-    { ...allFormValues, ...watchedRequiredFields } as OnboardingForm,
-    requiredFields,
-  );
-
-  const hasStepErrors = requiredFields.some((fieldName) =>
-    Boolean(form.formState.errors[fieldName]),
-  );
-
-  const isNextDisabled =
-    form.formState.isLoading ||
-    !hasAllRequiredValues ||
-    hasStepErrors ||
-    isPersonalBackgroundOverLimit;
 
   useEffect(() => {
     if (error) {

--- a/apps/web/src/pages/onboarding/onboarding-page.tsx
+++ b/apps/web/src/pages/onboarding/onboarding-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { FormProvider, useForm, useWatch } from 'react-hook-form';
+import { FormProvider, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 
 import {

--- a/apps/web/src/widgets/onboarding/index.ts
+++ b/apps/web/src/widgets/onboarding/index.ts
@@ -15,7 +15,9 @@ export { default as OnboardingStep } from './ui/onboarding-step/onboarding-step'
 export { default as OnboardingStepHeader } from './ui/onboarding-step-header/onboarding-step-header';
 export { default as OnboardingStepLayout } from './ui/onboarding-step-layout/onboarding-step-layout';
 export { default as OnboardingStepTitle } from './ui/onboarding-step-title/onboarding-step-title';
+export { default as CareerPreference } from './ui/step/career-preference/career-preference';
 export { default as EducationStep } from './ui/step/education/education';
+export { default as IdentityVisaVerification } from './ui/step/identity-visaVerification/identity-visaVerification';
 export { default as LanguageSkillStep } from './ui/step/language-skills/language-skills';
 export { default as PersonalBackgroundStep } from './ui/step/personal-backgorund/personal-background';
 export { default as PersonalInformationStep } from './ui/step/personal-information/personal-information';


### PR DESCRIPTION
## 📌 Summary
> - #330 

기존 온보딩 페이지는 스텝 검증 로직과 제출 로직이 전부 페이지 레이어에 인라인으로 구현되어 있었습니다. 
그러다 보니 다른 도메인 페이지 레이어에 비해 코드가 무거워지고 관심사가 섞여있어 바로 파악하기 어려운 상태였습니다. 

또한 다른 페이지 레이어에서는 위젯이나 피쳐 단위를 선언적으로 사용하고 있었기 때문에 코드의 일관성을 유지하고자 
인라인 로직을 커스텀 훅으로 분리하는 작업을 진행하게 되었습니다.

## 📚 Tasks
Page 레이어 Onboarding-page 인라인 로직 분리
- useOnboardingStepValidation 훅 분리 : 스텝별 필수 필드 계산 + 버튼 활성화 판단 
- useOnboardingSubmit 훅 분리 : 온보딩 제출 mutation

## 👀 To Reviewer

#### 훅 위치에 대해서
이번 작업에서 분리한 훅은 모두 온보딩 페이지에서만 사용하는 전용 훅으로 퍼널 구조에 의존하고 있습니다. 
그래서 위치를 위젯 레이어와 페이지 레이어 중 어디에 둘지 고민하다가 우선 페이지 레이어 안에 배치했습니다.

공식 문서에 
> "재사용되지 않고 특정 페이지의 핵심 콘텐츠에만 쓰인다면, 
굳이 Widget으로 분리하지 말고 Page 내부에 두는 것이 좋습니다."
- 참고: https://feature-sliced.design/kr/docs/reference/layers#widget

라고 나와있더라고요

다만 기존 페이지들은 보통 위젯, 피쳐 단위를 선언적으로 가져다 쓰는 구조였고
페이지 레이어 내부에서 훅을 분리하는 건 이번이 처음이라 이 방향이 괜찮을지 고민이 되는데 이 배치에 대한 의견 주시면 감사하겠씁니다

#### handleNext/handleBack 인라인 로직 유지
handleNext는 검증과 제출 과정에서 form, 검증 훅, 퍼널, 제출 훅까지 요소들을 하나로 엮는 역할을 합니다.
즉 이미 만들어진 값들을 조합하는 부분이라 훅으로 분리하면 오히려 파라미터를 6개나 넘겨야 하고 
재사용되는 곳도 없기 때문에 현재로서는 인라인으로 유지했습니다.
