### PR TITLE
Feat(web): 로드맵 생성 로딩 카드 구현

### DIFF
--- a/apps/web/src/features/onboarding/hooks/index.ts
+++ b/apps/web/src/features/onboarding/hooks/index.ts
@@ -1,3 +1,4 @@
 export { useIndustryField } from './useIndustryField';
+export { useRoadmapLoadingProgress } from './useRoadmapLoadingProgress';
 export { useTargetJobSkills } from './useTargetJobSkills';
 export { useVisaInformation } from './useVisaInformation';

--- a/apps/web/src/features/onboarding/hooks/useRoadmapLoadingProgress.ts
+++ b/apps/web/src/features/onboarding/hooks/useRoadmapLoadingProgress.ts
@@ -1,0 +1,33 @@
+import { useEffect, useState } from 'react';
+
+const STEP_DURATION_MS = 5_000;
+
+interface UseRoadmapLoadingProgressParams {
+  stepCount: number;
+  isRoadmapReady: boolean;
+}
+
+export const useRoadmapLoadingProgress = ({
+  stepCount,
+  isRoadmapReady,
+}: UseRoadmapLoadingProgressParams) => {
+  const [activeStepIndex, setActiveStepIndex] = useState(0);
+  const lastStepIndex = stepCount - 1;
+
+  useEffect(() => {
+    if (activeStepIndex === lastStepIndex) {
+      return;
+    }
+
+    const timer = window.setTimeout(
+      () => setActiveStepIndex((index) => index + 1),
+      STEP_DURATION_MS,
+    );
+
+    return () => window.clearTimeout(timer);
+  }, [activeStepIndex, lastStepIndex]);
+
+  const isComplete = activeStepIndex === lastStepIndex && isRoadmapReady;
+
+  return isComplete ? stepCount : activeStepIndex;
+};

--- a/apps/web/src/features/onboarding/ui/index.ts
+++ b/apps/web/src/features/onboarding/ui/index.ts
@@ -1,1 +1,5 @@
 export { default as LanguageSelector } from './language-selector/language-selector';
+export {
+  default as RoadmapLoadingCard,
+  type RoadmapLoadingCompletedStepCount,
+} from './roadmap-loading-card/roadmap-loading-card';

--- a/apps/web/src/features/onboarding/ui/index.ts
+++ b/apps/web/src/features/onboarding/ui/index.ts
@@ -1,5 +1,2 @@
 export { default as LanguageSelector } from './language-selector/language-selector';
-export {
-  default as RoadmapLoadingCard,
-  type RoadmapLoadingCompletedStepCount,
-} from './roadmap-loading-card/roadmap-loading-card';
+export { default as RoadmapLoadingCard } from './roadmap-loading-card/roadmap-loading-card';

--- a/apps/web/src/features/onboarding/ui/roadmap-loading-card/roadmap-loading-card.css.ts
+++ b/apps/web/src/features/onboarding/ui/roadmap-loading-card/roadmap-loading-card.css.ts
@@ -1,0 +1,245 @@
+import { themeVars, typography } from '@kds/ui/styles';
+import { keyframes, style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+const spin = keyframes({
+  to: { transform: 'rotate(360deg)' },
+});
+
+const fadeOut = keyframes({
+  to: { opacity: 0 },
+});
+
+const delayedTransition = '700ms';
+const reducedMotion = '(prefers-reduced-motion: reduce)';
+
+export const card = recipe({
+  base: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '56rem',
+    height: '44rem',
+    padding: '4rem',
+    gap: '3rem',
+    backgroundColor: themeVars.color.grayscale.white,
+    border: `1px solid ${themeVars.color.grayscale.gray300}`,
+    borderRadius: '20px',
+  },
+  variants: {
+    isComplete: {
+      true: {
+        animation: `${fadeOut} 300ms ease-in 700ms forwards`,
+        '@media': {
+          [reducedMotion]: {
+            animation: `${fadeOut} 1ms linear forwards`,
+          },
+        },
+      },
+      false: {},
+    },
+  },
+});
+
+export const heading = style({
+  ...typography.sub1_sb_22,
+  color: themeVars.color.grayscale.gray800,
+});
+
+export const screenReaderStatus = style({
+  position: 'absolute',
+  width: '1px',
+  height: '1px',
+  padding: 0,
+  margin: '-1px',
+  overflow: 'hidden',
+  clip: 'rect(0, 0, 0, 0)',
+  whiteSpace: 'nowrap',
+});
+
+export const stepList = style({
+  width: '100%',
+  overflow: 'hidden',
+});
+
+export const stepRow = recipe({
+  base: {
+    display: 'flex',
+    alignItems: 'center',
+    width: '100%',
+    height: '7.8rem',
+    padding: '1rem 1.4rem',
+    gap: '1.6rem',
+    borderRadius: '10px',
+    overflow: 'hidden',
+    transition: `background-color 300ms ease ${delayedTransition}`,
+    '@media': {
+      [reducedMotion]: { transition: 'none' },
+    },
+  },
+  variants: {
+    status: {
+      active: { backgroundColor: themeVars.color.grayscale.gray100 },
+      done: { backgroundColor: 'transparent' },
+      pending: { backgroundColor: 'transparent' },
+    },
+  },
+});
+
+export const statusIcon = style({
+  position: 'relative',
+  flexShrink: 0,
+  width: '2.4rem',
+  height: '2.4rem',
+});
+
+export const pendingIcon = recipe({
+  base: {
+    position: 'absolute',
+    inset: '0.2rem',
+    border: `2px solid ${themeVars.color.grayscale.gray300}`,
+    borderRadius: '50%',
+    transition: `opacity 300ms ease ${delayedTransition}`,
+    '@media': {
+      [reducedMotion]: { transition: 'none' },
+    },
+  },
+  variants: {
+    status: {
+      active: { opacity: 0 },
+      done: { opacity: 0, transitionDelay: '0ms' },
+      pending: { opacity: 1 },
+    },
+  },
+});
+
+export const loadingIcon = recipe({
+  base: {
+    position: 'absolute',
+    inset: '0.2rem',
+    border: `2px solid ${themeVars.color.primary[200]}`,
+    borderTopColor: themeVars.color.primary[500],
+    borderRadius: '50%',
+    animation: `${spin} 800ms linear infinite`,
+    transition: `opacity 300ms ease ${delayedTransition}`,
+    '@media': {
+      [reducedMotion]: {
+        animation: 'none',
+        transition: 'none',
+      },
+    },
+  },
+  variants: {
+    status: {
+      active: { opacity: 1 },
+      done: { opacity: 0, transition: 'opacity 220ms ease-out' },
+      pending: { opacity: 0 },
+    },
+  },
+});
+
+export const doneIcon = recipe({
+  base: {
+    position: 'absolute',
+    inset: '0.2rem',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: themeVars.color.grayscale.white,
+    backgroundColor: themeVars.color.primary[500],
+    borderRadius: '50%',
+    opacity: 0,
+    transform: 'scale(0.75)',
+    transition: 'opacity 220ms ease-out, transform 220ms ease-out',
+    '@media': {
+      [reducedMotion]: { transition: 'none' },
+    },
+  },
+  variants: {
+    status: {
+      active: {},
+      done: { opacity: 1, transform: 'scale(1)' },
+      pending: {},
+    },
+  },
+});
+
+export const stepContent = style({
+  display: 'flex',
+  flex: 1,
+  flexDirection: 'column',
+  minWidth: 0,
+  overflow: 'hidden',
+});
+
+export const stepTitle = recipe({
+  base: {
+    ...typography.body5_m_16,
+    transition: `color 300ms ease ${delayedTransition}, font-weight 300ms ease ${delayedTransition}`,
+    '@media': {
+      [reducedMotion]: { transition: 'none' },
+    },
+  },
+  variants: {
+    status: {
+      active: {
+        ...typography.body4_sb_16,
+        color: themeVars.color.grayscale.gray800,
+      },
+      done: { color: themeVars.color.grayscale.gray600 },
+      pending: { color: themeVars.color.grayscale.gray400 },
+    },
+  },
+});
+
+export const stepDescription = recipe({
+  base: {
+    ...typography.body9_r_14,
+    color: themeVars.color.grayscale.gray500,
+    maxHeight: 0,
+    marginTop: 0,
+    opacity: 0,
+    overflow: 'hidden',
+    transition: `max-height 300ms ease ${delayedTransition}, margin-top 300ms ease ${delayedTransition}, opacity 300ms ease ${delayedTransition}`,
+    '@media': {
+      [reducedMotion]: { transition: 'none' },
+    },
+  },
+  variants: {
+    status: {
+      active: { maxHeight: '1.7rem', marginTop: '0.5rem', opacity: 1 },
+      done: {},
+      pending: {},
+    },
+  },
+});
+
+export const connector = style({
+  position: 'relative',
+  display: 'block',
+  width: '0.2rem',
+  height: '3rem',
+  marginLeft: '2.5rem',
+  overflow: 'hidden',
+  backgroundColor: themeVars.color.grayscale.gray300,
+  borderRadius: '1px',
+});
+
+export const connectorFill = recipe({
+  base: {
+    position: 'absolute',
+    inset: 0,
+    backgroundColor: themeVars.color.primary[500],
+    transform: 'scaleY(0)',
+    transformOrigin: 'top',
+    transition: 'transform 520ms ease-in-out 180ms',
+    '@media': {
+      [reducedMotion]: { transition: 'none' },
+    },
+  },
+  variants: {
+    isActive: {
+      true: { transform: 'scaleY(1)' },
+      false: {},
+    },
+  },
+});

--- a/apps/web/src/features/onboarding/ui/roadmap-loading-card/roadmap-loading-card.tsx
+++ b/apps/web/src/features/onboarding/ui/roadmap-loading-card/roadmap-loading-card.tsx
@@ -1,0 +1,131 @@
+import { CheckIcon } from '@kds/icons';
+import type { AnimationEvent } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import * as styles from './roadmap-loading-card.css';
+
+export type RoadmapLoadingCompletedStepCount = 0 | 1 | 2 | 3;
+
+interface RoadmapLoadingCardProps {
+  name: string;
+  completedStepCount: RoadmapLoadingCompletedStepCount;
+  onExitComplete?: () => void;
+}
+
+type StepStatus = 'active' | 'done' | 'pending';
+
+const getStepStatus = (
+  stepIndex: number,
+  completedStepCount: RoadmapLoadingCompletedStepCount,
+): StepStatus => {
+  if (stepIndex < completedStepCount) {
+    return 'done';
+  }
+
+  if (stepIndex === completedStepCount) {
+    return 'active';
+  }
+
+  return 'pending';
+};
+
+const RoadmapLoadingCard = ({
+  name,
+  completedStepCount,
+  onExitComplete,
+}: RoadmapLoadingCardProps) => {
+  const { t } = useTranslation('onboarding');
+  const isComplete = completedStepCount === 3;
+  const steps = [
+    {
+      id: 'profileReview',
+      title: t('roadmapLoading.steps.profileReview.title', { name }),
+      description: t('roadmapLoading.steps.profileReview.description'),
+    },
+    {
+      id: 'jobMatching',
+      title: t('roadmapLoading.steps.jobMatching.title'),
+      description: t('roadmapLoading.steps.jobMatching.description'),
+    },
+    {
+      id: 'roadmapCreation',
+      title: t('roadmapLoading.steps.roadmapCreation.title', { name }),
+      description: t('roadmapLoading.steps.roadmapCreation.description'),
+    },
+  ];
+  const currentStep = steps[completedStepCount];
+  const stepItems = steps.map((step, index) => {
+    const status = getStepStatus(index, completedStepCount);
+    const isLastStep = index === steps.length - 1;
+
+    return {
+      ...step,
+      status,
+      hasConnector: !isLastStep,
+      isConnectorActive: status === 'done',
+    };
+  });
+
+  const handleAnimationEnd = (event: AnimationEvent<HTMLElement>) => {
+    if (event.target === event.currentTarget && isComplete) {
+      onExitComplete?.();
+    }
+  };
+
+  return (
+    <section
+      className={styles.card({ isComplete })}
+      onAnimationEnd={handleAnimationEnd}
+    >
+      <h2 className={styles.heading}>
+        {isComplete
+          ? t('roadmapLoading.completedTitle', { name })
+          : t('roadmapLoading.title')}
+      </h2>
+      <p className={styles.screenReaderStatus} role="status">
+        {currentStep?.title ?? t('roadmapLoading.completedTitle', { name })}
+      </p>
+      <div className={styles.stepList} role="list">
+        {stepItems.map(
+          ({
+            id,
+            title,
+            description,
+            status,
+            hasConnector,
+            isConnectorActive,
+          }) => (
+            <div key={id} role="listitem">
+              <div className={styles.stepRow({ status })}>
+                <span className={styles.statusIcon}>
+                  <span className={styles.pendingIcon({ status })} />
+                  <span className={styles.loadingIcon({ status })} />
+                  <span className={styles.doneIcon({ status })}>
+                    <CheckIcon width={16} height={16} />
+                  </span>
+                </span>
+                <span className={styles.stepContent}>
+                  <span className={styles.stepTitle({ status })}>{title}</span>
+                  <span className={styles.stepDescription({ status })}>
+                    {description}
+                  </span>
+                </span>
+              </div>
+              {hasConnector && (
+                <span className={styles.connector}>
+                  <span
+                    className={styles.connectorFill({
+                      isActive: isConnectorActive,
+                    })}
+                  />
+                </span>
+              )}
+            </div>
+          ),
+        )}
+      </div>
+    </section>
+  );
+};
+
+export default RoadmapLoadingCard;

--- a/apps/web/src/features/onboarding/ui/roadmap-loading-card/roadmap-loading-card.tsx
+++ b/apps/web/src/features/onboarding/ui/roadmap-loading-card/roadmap-loading-card.tsx
@@ -2,13 +2,13 @@ import { CheckIcon } from '@kds/icons';
 import type { AnimationEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
-import * as styles from './roadmap-loading-card.css';
+import { useRoadmapLoadingProgress } from '@features/onboarding/hooks';
 
-export type RoadmapLoadingCompletedStepCount = 0 | 1 | 2 | 3;
+import * as styles from './roadmap-loading-card.css';
 
 interface RoadmapLoadingCardProps {
   name: string;
-  completedStepCount: RoadmapLoadingCompletedStepCount;
+  isRoadmapReady: boolean;
   onExitComplete?: () => void;
 }
 
@@ -16,7 +16,7 @@ type StepStatus = 'active' | 'done' | 'pending';
 
 const getStepStatus = (
   stepIndex: number,
-  completedStepCount: RoadmapLoadingCompletedStepCount,
+  completedStepCount: number,
 ): StepStatus => {
   if (stepIndex < completedStepCount) {
     return 'done';
@@ -31,11 +31,10 @@ const getStepStatus = (
 
 const RoadmapLoadingCard = ({
   name,
-  completedStepCount,
+  isRoadmapReady,
   onExitComplete,
 }: RoadmapLoadingCardProps) => {
   const { t } = useTranslation('onboarding');
-  const isComplete = completedStepCount === 3;
   const steps = [
     {
       id: 'profileReview',
@@ -53,6 +52,11 @@ const RoadmapLoadingCard = ({
       description: t('roadmapLoading.steps.roadmapCreation.description'),
     },
   ];
+  const completedStepCount = useRoadmapLoadingProgress({
+    stepCount: steps.length,
+    isRoadmapReady,
+  });
+  const isComplete = completedStepCount === steps.length;
   const currentStep = steps[completedStepCount];
   const stepItems = steps.map((step, index) => {
     const status = getStepStatus(index, completedStepCount);

--- a/apps/web/src/shared/i18n/locales/en/onboarding.json
+++ b/apps/web/src/shared/i18n/locales/en/onboarding.json
@@ -13,6 +13,24 @@
       "background": "Background"
     }
   },
+  "roadmapLoading": {
+    "title": "Building your personalized roadmap",
+    "completedTitle": "{{name}}, your roadmap is ready",
+    "steps": {
+      "profileReview": {
+        "title": "Reviewing {{name}}’s profile",
+        "description": "Checking your visa type, major, and Korean proficiency."
+      },
+      "jobMatching": {
+        "title": "Finding matching jobs and visa options",
+        "description": "Checking your visa type, major, and Korean proficiency."
+      },
+      "roadmapCreation": {
+        "title": "Building {{name}}’s personalized roadmap",
+        "description": "Almost there—we’re putting the finishing touches on your roadmap."
+      }
+    }
+  },
   "steps": {
     "identityVisaVerification": {
       "upload": {

--- a/apps/web/src/shared/i18n/locales/ko/onboarding.json
+++ b/apps/web/src/shared/i18n/locales/ko/onboarding.json
@@ -13,6 +13,24 @@
       "background": "배경 정보"
     }
   },
+  "roadmapLoading": {
+    "title": "맞춤형 로드맵을 만들고 있어요",
+    "completedTitle": "{{name}}님, 로드맵이 준비됐어요",
+    "steps": {
+      "profileReview": {
+        "title": "{{name}}님의 프로필을 검토하고 있어요",
+        "description": "비자 유형, 전공, 한국어 능력을 확인하고 있어요."
+      },
+      "jobMatching": {
+        "title": "적합한 직무와 비자 옵션을 찾고 있어요",
+        "description": "비자 유형, 전공, 한국어 능력을 확인하고 있어요."
+      },
+      "roadmapCreation": {
+        "title": "{{name}}님의 맞춤형 로드맵을 만들고 있어요",
+        "description": "거의 다 됐어요. 로드맵을 마무리하고 있어요."
+      }
+    }
+  },
   "steps": {
     "identityVisaVerification": {
       "upload": {

--- a/apps/web/src/shared/i18n/locales/vi/onboarding.json
+++ b/apps/web/src/shared/i18n/locales/vi/onboarding.json
@@ -13,6 +13,24 @@
       "background": "Thông tin bổ sung"
     }
   },
+  "roadmapLoading": {
+    "title": "Đang xây dựng lộ trình cá nhân hóa của bạn",
+    "completedTitle": "{{name}}, lộ trình của bạn đã sẵn sàng",
+    "steps": {
+      "profileReview": {
+        "title": "Đang xem xét hồ sơ của {{name}}",
+        "description": "Đang kiểm tra loại thị thực, chuyên ngành và trình độ tiếng Hàn của bạn."
+      },
+      "jobMatching": {
+        "title": "Đang tìm công việc và lựa chọn thị thực phù hợp",
+        "description": "Đang kiểm tra loại thị thực, chuyên ngành và trình độ tiếng Hàn của bạn."
+      },
+      "roadmapCreation": {
+        "title": "Đang xây dựng lộ trình cá nhân hóa cho {{name}}",
+        "description": "Sắp xong rồi—chúng tôi đang hoàn thiện lộ trình của bạn."
+      }
+    }
+  },
   "steps": {
     "identityVisaVerification": {
       "upload": {

--- a/apps/web/src/shared/i18n/locales/zh-CN/onboarding.json
+++ b/apps/web/src/shared/i18n/locales/zh-CN/onboarding.json
@@ -13,6 +13,24 @@
       "background": "背景信息"
     }
   },
+  "roadmapLoading": {
+    "title": "正在生成你的个性化职业路线图",
+    "completedTitle": "{{name}}，你的职业路线图已准备好",
+    "steps": {
+      "profileReview": {
+        "title": "正在查看{{name}}的资料",
+        "description": "正在核对你的签证类型、专业和韩语水平。"
+      },
+      "jobMatching": {
+        "title": "正在匹配职位和签证方案",
+        "description": "正在核对你的签证类型、专业和韩语水平。"
+      },
+      "roadmapCreation": {
+        "title": "正在生成{{name}}的个性化职业路线图",
+        "description": "快完成了——我们正在完善你的职业路线图。"
+      }
+    }
+  },
   "steps": {
     "identityVisaVerification": {
       "upload": {


### PR DESCRIPTION
## 📌 Summary

<!-- 관련 Issue를 태그해주세요 -->
<!-- 해당 PR에 대한 작업 내용을 요약하여 작성해주세요. -->

> - #335

온보딩 완료 후 AI 로드맵이 생성되는 동안 진행 상황을 보여주는 Loading Card 컴포넌트를 구현했어요.

## 📚 Tasks

<!-- 완료한 작업을 작성해 주세요 -->

- 로드맵 생성 Loading Card 컴포넌트 구현
- 단계별 `active`, `done`, `pending` 상태 UI 구현
- 1·2단계 5초 자동 진행 및 마지막 단계 서버 응답 대기 로직 구현
- 단계 완료, 연결선 진행, 다음 단계 활성화 모션 적용
- 로드맵 생성 완료 후 카드 퇴장 모션과 완료 콜백 구현

## 👀 To Reviewer

### Loading Card 컴포넌트 위치

처음에는 다른 화면에서도 사용할 수 있도록 `packages/kds-ui`에 구현하는 방법을 고려했어요.

하지만 이 컴포넌트는 온보딩에서 입력한 사용자 이름을 사용하고, 로드맵 생성 단계와 서버의 생성 완료 상태에 따라 동작해요. UI 구조뿐만 아니라 온보딩 도메인의 문구와 진행 규칙까지 포함하고 있어서 범용 UI 컴포넌트로 보기 어렵다고 판단했어요.

따라서 공통 디자인 시스템인 `packages/kds-ui`가 아니라 `apps/web/src/features/onboarding` 내부에 구현했어요.

### 단계 진행 방식

온보딩 API 호출 이후 서버에서 AI 로드맵을 생성하는 동안 사용자가 현재 어떤 작업이 진행되고 있는지 확인할 수 있도록 세 단계로 구성했어요.

첫 번째 단계와 두 번째 단계는 각각 5초 동안 노출된 뒤 자동으로 다음 단계로 넘어가요. 마지막 단계에서는 임의로 완료 처리하지 않고 서버의 로드맵 생성 완료 상태를 기다리도록 구성했어요.

```text
프로필 검토 5초
→ 직무 및 비자 옵션 분석 5초
→ 로드맵 생성 완료 응답 대기
```

단계 진행 시간을 CSS 애니메이션으로 처리하는 방법도 고려했어요. 하지만 CSS는 화면에 보이는 모션만 제어할 수 있고, 현재 활성화된 단계나 서버의 생성 완료 상태와 같은 React 상태를 변경할 수 없어요.

따라서 단계 진행은 `useRoadmapLoadingProgress` Hook에서 관리하고, CSS는 각 상태에 대응하는 모션만 담당하도록 역할을 분리했어요. 진행 규칙은 온보딩 도메인의 로직이라고 판단해 Loading Card 폴더가 아닌 `features/onboarding/hooks`에 배치했어요.

### 서버 상태와 컴포넌트 Props

Loading Card 내부에서 API나 SSE를 직접 연결하지 않고, 사용하는 페이지에서 서버 상태를 전달하도록 구성했어요.

추후 Home에서 SSE를 연결하면 서버로부터 받은 로드맵 생성 완료 상태를 `isRoadmapReady`로 전달할 예정이에요. 컴포넌트가 네트워크 요청까지 직접 담당하면 UI와 서버 통신 로직이 결합되고, API 호출 방식이 변경될 때 컴포넌트도 함께 수정해야 한다고 판단했어요.

현재 Props는 다음 역할을 담당해요.

- `name`: 단계 문구와 완료 제목에 표시할 사용자 이름
- `isRoadmapReady`: 서버에서 로드맵 생성이 완료됐는지 나타내는 상태
- `onExitComplete`: 카드 퇴장 모션이 끝난 뒤 상위 화면에 완료 사실을 전달하는 콜백

`onExitComplete`에서는 Loading Card가 직접 페이지를 이동하거나 Home을 렌더링하지 않아요. 카드가 사라진 이후 어떤 화면을 보여줄지는 사용하는 페이지에서 결정하도록 분리했어요.

### 단계 상태 구성

각 단계에는 `profileReview`, `jobMatching`, `roadmapCreation`처럼 의미를 알 수 있는 `id`를 추가했어요. 번역된 제목을 React의 `key`로 사용하면 언어가 변경될 때 key도 함께 변경되기 때문에 단계 자체를 식별할 수 있는 값을 별도로 사용했어요.

현재 완료된 단계 수를 기준으로 각 단계를 다음 세 가지 상태로 변환해요.

- `active`: 현재 진행 중인 단계
- `done`: 완료된 단계
- `pending`: 아직 시작하지 않은 단계

### 모션 적용 방식

단계가 완료되면 로딩 아이콘이 체크 아이콘으로 전환되고, 이후 연결선이 위에서 아래로 채워진 뒤 다음 단계가 활성화돼요.

```text
로딩 아이콘
→ 체크 아이콘 전환
→ 연결선 채우기
→ 다음 단계 활성화
```

피그마에 정의된 순서에 맞춰 체크 전환은 220ms, 연결선은 180ms 이후 520ms 동안 진행되도록 적용했어요. 연결선 모션이 끝나는 700ms 시점부터 다음 단계의 배경과 설명이 나타나도록 구성했어요.

마지막 단계까지 완료되면 제목을 완료 문구로 변경하고, 700ms 동안 완료 상태를 보여준 뒤 카드를 300ms 동안 페이드아웃해요. 카드의 퇴장 모션이 끝나면 `onExitComplete`를 호출해 상위 화면에서 다음 UI를 렌더링할 수 있도록 했어요.

이번 PR에는 실제 API 및 SSE 연결은 포함하지 않았어요. 서버 연동 시에는 Loading Card의 내부 구조를 변경하지 않고 `isRoadmapReady` 값만 전달하면 돼요.

## 📸 Screenshot

https://github.com/user-attachments/assets/f85ab687-f236-4738-b9bc-cf80e2ed2dad


